### PR TITLE
Frontend widget to create a SQL cell and run code

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,4 +1,12 @@
 {
+  "jupyter.lab.toolbars": {
+    "Notebook": [
+      {
+        "name": "SqlWidget",
+        "rank": 50
+      }
+    ]
+  },
   "jupyter.lab.shortcuts": [],
   "title": "@jupyter/sql-cell",
   "description": "@jupyter/sql-cell settings.",

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -1,0 +1,133 @@
+import { Cell, ICellModel } from '@jupyterlab/cells';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import {
+  ToolbarButtonComponent,
+  ReactWidget,
+  UseSignal,
+  runIcon
+} from '@jupyterlab/ui-components';
+import { CommandRegistry } from '@lumino/commands';
+import { Signal } from '@lumino/signaling';
+import * as React from 'react';
+
+export class SqlWidget extends ReactWidget {
+  /**
+   * The constructor of the widget.
+   */
+  constructor(options: Private.IOptions) {
+    super();
+    this._commands = options.commands;
+    this._commandID = options.commandID;
+    this._tracker = options.tracker;
+    this._activeCell = this._tracker.activeCell;
+  }
+
+  /**
+   * Execute the command.
+   */
+  private _run() {
+    this._commands.execute(this._commandID);
+  }
+
+  /**
+   * Switch the status of the cell, SQL cell or not.
+   *
+   * @param event - the mouse event that triggered the function.
+   */
+  private _switch(event: React.ChangeEvent) {
+    const model = this._tracker.activeCell?.model;
+    if (!model || model.type !== 'raw') {
+      return;
+    }
+    model.setMetadata('sql-cell', (event.target as HTMLInputElement).checked);
+  }
+
+  /**
+   * A signal used to handle the metadata changed on the current cell.
+   *
+   * ## FIXME:
+   * We should use an other signal, the widget should update with the original
+   * metadata change signal.
+   */
+  private _metadataChanged = () => {
+    this._signal.emit();
+  };
+
+  /**
+   * The definition of the widget to display.
+   *
+   * @returns - React element corresponding to the widget.
+   */
+  private _widget = () => {
+    if (this._activeCell?.model) {
+      this._activeCell.model.metadataChanged.disconnect(this._metadataChanged);
+    }
+
+    this._activeCell = this._tracker.activeCell;
+    if (this._activeCell?.model) {
+      this._activeCell?.model.metadataChanged.connect(this._metadataChanged);
+    }
+
+    return (
+      <UseSignal signal={this._signal}>
+        {() => (
+          <div
+            className={'sql-cell-widget'}
+            aria-disabled={this._tracker.activeCell?.model.type !== 'raw'}
+          >
+            <span>SQL cell</span>
+            <label className={'switch'}>
+              <input
+                type={'checkbox'}
+                className={'sql-cell-check'}
+                disabled={this._tracker.activeCell?.model.type !== 'raw'}
+                aria-disabled={this._tracker.activeCell?.model.type !== 'raw'}
+                onChange={event => this._switch(event)}
+                checked={this._tracker.activeCell?.model.getMetadata(
+                  'sql-cell'
+                )}
+              />
+              <span className={'slider'}></span>
+            </label>
+            <ToolbarButtonComponent
+              enabled={
+                this._tracker.activeCell?.model.type === 'raw' &&
+                this._tracker.activeCell?.model.getMetadata('sql-cell') === true
+              }
+              icon={runIcon}
+              onClick={this._run.bind(this)}
+            ></ToolbarButtonComponent>
+          </div>
+        )}
+      </UseSignal>
+    );
+  };
+
+  render(): JSX.Element {
+    return (
+      <UseSignal signal={this._tracker.activeCellChanged}>
+        {this._widget}
+      </UseSignal>
+    );
+  }
+
+  private _commands: CommandRegistry;
+  private _commandID: string;
+  private _tracker: INotebookTracker;
+  private _activeCell: Cell<ICellModel> | null;
+  private _signal = new Signal<this, void>(this);
+}
+
+/**
+ * The Private namespace.
+ */
+namespace Private {
+  /**
+   * The interface of the options of the SqlWidget constructor.
+   */
+  export interface IOptions {
+    commands: CommandRegistry;
+    commandID: string;
+    tracker: INotebookTracker;
+  }
+}

--- a/style/base.css
+++ b/style/base.css
@@ -10,7 +10,7 @@
   align-items: center;
 }
 
-.sql-cell-widget[aria-disabled="true"] span:first-child {
+.sql-cell-widget[aria-disabled='true'] span:first-child {
   color: var(--jp-ui-font-color3);
 }
 
@@ -20,7 +20,6 @@
   align-content: center;
   flex-wrap: wrap;
   height: 100%;
-
 }
 
 /* Hide default HTML checkbox */
@@ -35,20 +34,20 @@
   cursor: pointer;
   height: 15px;
   width: 30px;
-  background-color:var(--jp-layout-color3);
-  -webkit-transition: .4s;
-  transition: .4s;
+  background-color: var(--jp-layout-color3);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
   border-radius: 15px;
 }
 
-.sql-cell-widget .slider:before {
+.sql-cell-widget .slider::before {
   display: block;
-  content: "";
+  content: '';
   height: 15px;
   width: 15px;
   background-color: white;
-  -webkit-transition: .4s;
-  transition: .4s;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
   border-radius: 50%;
 }
 
@@ -65,12 +64,13 @@
   cursor: not-allowed;
 }
 
-.sql-cell-widget input:checked + .slider:before {
+.sql-cell-widget input:checked + .slider::before {
   -webkit-transform: translateX(15px);
   -ms-transform: translateX(15px);
   transform: translateX(15px);
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .sql-cell-widget .jp-ToolbarButtonComponent {
   height: 22px;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -3,3 +3,74 @@
 
     https://jupyterlab.readthedocs.io/en/stable/developer/css.html
 */
+
+.sql-cell-widget {
+  display: flex;
+  border: solid 1px;
+  align-items: center;
+}
+
+.sql-cell-widget[aria-disabled="true"] span:first-child {
+  color: var(--jp-ui-font-color3);
+}
+
+.sql-cell-widget .switch {
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  flex-wrap: wrap;
+  height: 100%;
+
+}
+
+/* Hide default HTML checkbox */
+.sql-cell-widget .switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.sql-cell-widget .slider {
+  cursor: pointer;
+  height: 15px;
+  width: 30px;
+  background-color:var(--jp-layout-color3);
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 15px;
+}
+
+.sql-cell-widget .slider:before {
+  display: block;
+  content: "";
+  height: 15px;
+  width: 15px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+.sql-cell-widget input:checked + .slider {
+  background-color: var(--md-blue-500);
+}
+
+.sql-cell-widget input:focus + .slider {
+  box-shadow: 0 0 1px var(--md-blue-500);
+}
+
+.sql-cell-widget input:disabled + .slider {
+  background-color: var(--jp-layout-color2);
+  cursor: not-allowed;
+}
+
+.sql-cell-widget input:checked + .slider:before {
+  -webkit-transform: translateX(15px);
+  -ms-transform: translateX(15px);
+  transform: translateX(15px);
+}
+
+.sql-cell-widget .jp-ToolbarButtonComponent {
+  height: 22px;
+}


### PR DESCRIPTION
This PR adds a widget in the notebook toolbar to:

- set the active raw cell as an SQL cell
- run SQL from the active SQL cell

![Peek 2023-09-26 12-13](https://github.com/QuantStack/jupyter-sql-cell/assets/32258950/1477d263-3d1b-4c23-bb0e-fb165bd102f4)
