### PR TITLE
Overwrite the core functions to run cells

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -11,7 +11,7 @@ export namespace CommandIDs {
   /**
    * Execute the query on the server.
    */
-  export const run = 'jupyter-sql-cell:execute';
+  export const execute = 'jupyter-sql-cell:execute';
 }
 
 /**

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -27,7 +27,7 @@ export class SqlWidget extends ReactWidget {
    * Execute the command.
    */
   private _run() {
-    this._commands.execute(CommandIDs.run);
+    this._commands.execute(CommandIDs.execute);
   }
 
   /**


### PR DESCRIPTION
This pull request overwrites the functions running cells, to also run the SQL cells.

This allow using the same shortcuts / menu / toolbar-buttons than the ones used to run the regular code cells.

[ ] add tests
[ ] remove buttons to run SQL cell in toolbars

This is a draft PR as it could be replaced by the use of *xeus-sql* kernel and *allthekernels*