### PR TITLE
Content factories

### DIFF
--- a/jupyter_sql_cell/sqlconnector.py
+++ b/jupyter_sql_cell/sqlconnector.py
@@ -28,6 +28,7 @@ class Database(TypedDict):
 
 
 class DatabaseSummary(DatabaseDesc):
+    alias: str
     id: int
     is_async: bool
 
@@ -149,7 +150,7 @@ class SQLConnector:
             if url.port:
                 summary["port"] = url.port
             summary_databases.append(summary)
-        return summary_databases
+        return sorted(summary_databases, key=lambda d: d['alias'].upper())
 
     @staticmethod
     def to_list(cursor: CursorResult[Any]) -> List[Dict]:

--- a/jupyter_sql_cell/tests/test_connector.py
+++ b/jupyter_sql_cell/tests/test_connector.py
@@ -48,11 +48,10 @@ async def test_sql_connector_init():
 
 
 """
-Should add an async database.
+Should add a default driver.
 """
 async def test_sql_connector_without_driver(add_database):
     assert len(SQLConnector.databases) == 1
-    assert len(SQLConnector.warnings) == 0
     connector = SQLConnector(0)
     assert len(connector.errors) == 0
 
@@ -62,7 +61,6 @@ Should add a sync database.
 """
 async def test_sql_connector_with_sync_driver(add_sync_database):
     assert len(SQLConnector.databases) == 1
-    assert len(SQLConnector.warnings) == 1
     connector = SQLConnector(0)
     assert len(connector.errors) == 0
 

--- a/package.json
+++ b/package.json
@@ -56,12 +56,18 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
+        "@jupyter/ydoc": "^1.0.0",
         "@jupyterlab/application": "^4.0.0",
+        "@jupyterlab/cells": "^4.0.0",
+        "@jupyterlab/codeeditor": "^4.0.0",
         "@jupyterlab/coreutils": "^6.0.0",
+        "@jupyterlab/notebook": "^4.0.0",
         "@jupyterlab/services": "^7.0.0",
         "@jupyterlab/settingregistry": "^4.0.0",
         "@jupyterlab/translation": "^4.0.0",
         "@jupyterlab/ui-components": "^4.0.0",
+        "@lumino/coreutils": "^2.0.0",
+        "@lumino/messaging": "^2.0.0",
         "@lumino/signaling": "^2.0.0",
         "@lumino/widgets": "^2.0.0",
         "react": "^18.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.0.1,<3",
     "SQLAlchemy[asyncio]>=2.0.0",
-    "jupysql"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "aiosqlite",
     "jupyter_server>=2.0.1,<3",
-    "SQLAlchemy[asyncio]>=2.0.0"
+    "SQLAlchemy[asyncio]>=2.0.0",
+    "jupysql"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/src/cellfactory.ts
+++ b/src/cellfactory.ts
@@ -156,6 +156,7 @@ export class CellHeader extends Widget implements ICellHeader {
   private _checkSource() {
     if (!this._kernelInjection.status) {
       this._setCellSql(false);
+      return;
     }
     const sourceStart = this._cellModel?.sharedModel.source.substring(0, 5);
     if (sourceStart === MAGIC && !this._isSQL) {

--- a/src/cellfactory.ts
+++ b/src/cellfactory.ts
@@ -1,0 +1,187 @@
+import { CellChange, ISharedCodeCell } from '@jupyter/ydoc';
+import { Cell, CodeCell, ICellHeader, ICodeCellModel } from '@jupyterlab/cells';
+import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
+import { ReactWidget, ReactiveToolbar } from '@jupyterlab/ui-components';
+import { Message } from '@lumino/messaging';
+import { SingletonLayout, Widget } from '@lumino/widgets';
+
+import { IDatabasesPanel } from './sidepanel';
+import { DatabaseSelect } from './widgets';
+
+/**
+ * The class of the header.
+ */
+const HEADER_CLASS = 'jp-sqlcell-header';
+
+/**
+ * The expected magic.
+ */
+const MAGIC = '%%sql';
+
+/**
+ * The notebook content factory.
+ */
+export class NotebookContentFactory
+  extends Notebook.ContentFactory
+  implements NotebookPanel.IContentFactory
+{
+  constructor(options: ContentFactory.IOptions) {
+    super(options);
+    this._databasesPanel = options.databasesPanel;
+  }
+
+  /**
+   * Create a new content area for the panel.
+   */
+  createNotebook(options: Notebook.IOptions): Notebook {
+    return new Notebook(options);
+  }
+
+  /**
+   * Creates a new code cell widget, using a custom content factory.
+   */
+  createCodeCell(options: CodeCell.IOptions): CodeCell {
+    const editorFactory = options.contentFactory.editorFactory;
+    const databasesPanel = this._databasesPanel;
+    const cellContentFactory = new CellContentFactory({
+      databasesPanel,
+      editorFactory
+    });
+    const cell = new CodeCell({
+      ...options,
+      contentFactory: cellContentFactory
+    }).initializeState();
+    return cell;
+  }
+
+  private _databasesPanel: IDatabasesPanel;
+}
+
+/**
+ * The cell content factory.
+ */
+export class CellContentFactory
+  extends Cell.ContentFactory
+  implements Cell.IContentFactory
+{
+  /**
+   * Create a content factory for a cell.
+   */
+  constructor(options: ContentFactory.IOptions) {
+    super(options);
+    this._databasesPanel = options.databasesPanel;
+  }
+
+  /**
+   * Create a new cell header for the parent widget.
+   */
+  createCellHeader(): ICellHeader {
+    const databasesPanel = this._databasesPanel;
+    return new CellHeader({ databasesPanel });
+  }
+
+  private _databasesPanel: IDatabasesPanel;
+}
+
+/**
+ * The cell header widget.
+ */
+export class CellHeader extends Widget implements ICellHeader {
+  /**
+   * Creates a cell header.
+   */
+  constructor(options: { databasesPanel: IDatabasesPanel }) {
+    super();
+    this.layout = new SingletonLayout();
+    this._databasesPanel = options.databasesPanel;
+
+    this._toolbar = new ReactiveToolbar();
+  }
+
+  /**
+   * Set the cell model to the header.
+   *
+   * It adds a listener on the cell content to display or not the toolbar.
+   */
+  set cellModel(model: ICodeCellModel | null) {
+    this._cellModel = model;
+    this._cellModel?.sharedModel.changed.connect(
+      this._onSharedModelChanged,
+      this
+    );
+
+    const databaseSelect = ReactWidget.create(
+      DatabaseSelect({
+        cellModel: this._cellModel,
+        databasesPanel: this._databasesPanel
+      })
+    );
+    this._toolbar.addItem('select', databaseSelect);
+
+    this._checkSource();
+  }
+
+  /**
+   * Check the source of the cell for the MAGIC command, and attach or detach
+   * the toolbar if necessary.
+   */
+  private _checkSource() {
+    const sourceStart = this._cellModel?.sharedModel.source.substring(0, 5);
+    if (sourceStart === MAGIC && !this._isSQL) {
+      this._isSQL = true;
+      this.addClass(HEADER_CLASS);
+      (this.layout as SingletonLayout).widget = this._toolbar;
+    } else if (sourceStart !== MAGIC && this._isSQL) {
+      this._isSQL = false;
+      this.removeClass(HEADER_CLASS);
+      (this.layout as SingletonLayout).removeWidget(this._toolbar);
+    }
+  }
+
+  /**
+   * Triggered when the shared model change.
+   */
+  private _onSharedModelChanged = (_: ISharedCodeCell, change: CellChange) => {
+    if (change.sourceChange) {
+      this._checkSource();
+    }
+  };
+
+  /**
+   * Triggered when the widget has been attached.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this.cellModel = (this.parent as CodeCell).model;
+  }
+
+  /**
+   * Triggered before the widget is detached.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    (this.layout as SingletonLayout).removeWidget(this._toolbar);
+    this._cellModel?.sharedModel.changed.disconnect(
+      this._onSharedModelChanged,
+      this
+    );
+  }
+
+  private _databasesPanel: IDatabasesPanel;
+  private _cellModel: ICodeCellModel | null = null;
+  private _isSQL = false;
+  private _toolbar: ReactiveToolbar;
+}
+
+/**
+ * The namespace for content factory.
+ */
+export namespace ContentFactory {
+  /**
+   * The content factory options.
+   */
+  export interface IOptions extends Cell.ContentFactory.IOptions {
+    /**
+     * The databases panel, containing the known databases.
+     */
+    databasesPanel: IDatabasesPanel;
+  }
+}

--- a/src/cellfactory.ts
+++ b/src/cellfactory.ts
@@ -5,6 +5,7 @@ import { ReactWidget, ReactiveToolbar } from '@jupyterlab/ui-components';
 import { Message } from '@lumino/messaging';
 import { SingletonLayout, Widget } from '@lumino/widgets';
 
+import { MAGIC } from './common';
 import { IDatabasesPanel } from './sidepanel';
 import { DatabaseSelect } from './widgets';
 
@@ -12,11 +13,6 @@ import { DatabaseSelect } from './widgets';
  * The class of the header.
  */
 const HEADER_CLASS = 'jp-sqlcell-header';
-
-/**
- * The expected magic.
- */
-const MAGIC = '%%sql';
 
 /**
  * The notebook content factory.

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,9 @@
 /**
+ * The code to inject to the kernel to load the sql magic.
+ */
+export const LOAD_MAGIC = '%load_ext sql';
+
+/**
  * The expected magic.
  */
 export const MAGIC = '%%sql';

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,4 @@
+/**
+ * The expected magic.
+ */
+export const MAGIC = '%%sql';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,13 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-
+import { IEditorServices } from '@jupyterlab/codeeditor';
+import { NotebookPanel } from '@jupyterlab/notebook';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
-import { Databases } from './sidepanel';
+import { NotebookContentFactory } from './cellfactory';
+import { Databases, IDatabasesPanel } from './sidepanel';
 
 /**
  * The sql-cell namespace token.
@@ -17,17 +19,18 @@ const namespace = 'sql-cell';
 /**
  * The side panel to handle the list of databases.
  */
-const plugin: JupyterFrontEndPlugin<void> = {
+const plugin: JupyterFrontEndPlugin<IDatabasesPanel> = {
   id: '@jupyter/sql-cell:plugin',
   description: 'The side panel which handle databases list.',
   autoStart: true,
   optional: [ILayoutRestorer, ISettingRegistry, ITranslator],
+  provides: IDatabasesPanel,
   activate: (
     app: JupyterFrontEnd,
     restorer: ILayoutRestorer | null,
     settingRegistry: ISettingRegistry | null,
     translator: ITranslator | null
-  ) => {
+  ): IDatabasesPanel => {
     if (settingRegistry) {
       settingRegistry
         .load(plugin.id)
@@ -54,7 +57,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
     }
 
     shell.add(panel, 'left');
+    return panel;
   }
 };
 
-export default [plugin];
+/**
+ * The notebook cell factory provider, to add a custom header to the code cells.
+ */
+const NotebookFactory: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
+  id: '@jupyter/sql-cell:content-factory',
+  description: 'Provides the notebook content factory.',
+  provides: NotebookPanel.IContentFactory,
+  requires: [IDatabasesPanel, IEditorServices],
+  autoStart: true,
+  activate: (
+    app: JupyterFrontEnd,
+    databasesPanel: IDatabasesPanel,
+    editorServices: IEditorServices
+  ) => {
+    const editorFactory = editorServices.factoryService.newInlineEditor;
+    return new NotebookContentFactory({ databasesPanel, editorFactory });
+  }
+};
+
+export default [NotebookFactory, plugin];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,16 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
+import { ISessionContext } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
-import { NotebookPanel } from '@jupyterlab/notebook';
+import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
+import { KernelMessage, Session } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 import { NotebookContentFactory } from './cellfactory';
+import { LOAD_MAGIC } from './common';
+import { IKernelInjection, KernelInjection } from './kernelInjection';
 import { Databases, IDatabasesPanel } from './sidepanel';
 
 /**
@@ -64,20 +68,100 @@ const plugin: JupyterFrontEndPlugin<IDatabasesPanel> = {
 /**
  * The notebook cell factory provider, to add a custom header to the code cells.
  */
-const NotebookFactory: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
+const notebookFactory: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
   id: '@jupyter/sql-cell:content-factory',
   description: 'Provides the notebook content factory.',
   provides: NotebookPanel.IContentFactory,
-  requires: [IDatabasesPanel, IEditorServices],
+  requires: [IDatabasesPanel, IEditorServices, IKernelInjection],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     databasesPanel: IDatabasesPanel,
-    editorServices: IEditorServices
+    editorServices: IEditorServices,
+    kernelInjection: IKernelInjection
   ) => {
     const editorFactory = editorServices.factoryService.newInlineEditor;
-    return new NotebookContentFactory({ databasesPanel, editorFactory });
+    return new NotebookContentFactory({
+      databasesPanel,
+      editorFactory,
+      kernelInjection
+    });
   }
 };
 
-export default [NotebookFactory, plugin];
+/**
+ * A plugin to provides the kernel injection status.
+ */
+const kernelInjection: JupyterFrontEndPlugin<IKernelInjection> = {
+  id: '@jupyter/sql-cell:kernel-injection',
+  description: 'A JupyterLab extension to provide the kernel injection status',
+  autoStart: true,
+  provides: IKernelInjection,
+  activate: (app: JupyterFrontEnd): IKernelInjection => {
+    return new KernelInjection();
+  }
+};
+
+/*
+ * A plugin to inject a function in the notebook kernel.
+ *
+ * ### NOTES:
+ * This plugin must be separated from 'kernelInjection' to avoid cycle dependencies.
+ * Indeed, this plugin requires 'INotebookTracker', which requires
+ * 'NotebookPanel.IContentFactory'.
+ * However, the custom 'NotebookPanel.IContentFactory', provided here in
+ * 'notebookFactory', requires 'kernelInjection'.
+ */
+const kernelInjector: JupyterFrontEndPlugin<void> = {
+  id: '@jupyter/sql-cell:kernel-injector',
+  description: 'A JupyterLab extension to inject code in notebook kernel',
+  autoStart: true,
+  requires: [IKernelInjection, INotebookTracker],
+  activate: (
+    app: JupyterFrontEnd,
+    kernelInjection: IKernelInjection,
+    tracker: INotebookTracker
+  ) => {
+    let sessionContext: ISessionContext | undefined = undefined;
+
+    /**
+     * Triggered when the current notebook or current kernel changes.
+     */
+    const onKernelChanged = async (
+      _sessionContext: ISessionContext,
+      kernelChange: Session.ISessionConnection.IKernelChangedArgs
+    ) => {
+      kernelInjection.status = false;
+      const kernel = kernelChange.newValue;
+      if (kernel) {
+        kernel.info.then(info => {
+          const code = LOAD_MAGIC;
+          const content: KernelMessage.IExecuteRequestMsg['content'] = { code };
+          const future = kernel.requestExecute(content);
+          future.done.then(reply => {
+            kernelInjection.status = reply.content.status === 'ok';
+            if (!(reply.content.status === 'ok')) {
+              console.warn('The kernel does not support SQL magics');
+            }
+          });
+        });
+      }
+    };
+
+    tracker.currentChanged.connect((_, panel) => {
+      sessionContext?.kernelChanged.disconnect(onKernelChanged);
+      sessionContext = panel?.sessionContext;
+      const kernel = sessionContext?.session?.kernel;
+      if (sessionContext && kernel) {
+        onKernelChanged(sessionContext, {
+          name: 'kernel',
+          oldValue: null,
+          newValue: kernel
+        });
+      }
+      sessionContext?.kernelChanged.connect(onKernelChanged);
+    });
+  }
+};
+
+export default [kernelInjection, kernelInjector, notebookFactory, plugin];

--- a/src/kernelInjection.ts
+++ b/src/kernelInjection.ts
@@ -1,0 +1,42 @@
+import { Token } from '@lumino/coreutils';
+import { ISignal, Signal } from '@lumino/signaling';
+
+/**
+ * The kernel injection token.
+ */
+export const IKernelInjection = new Token<IKernelInjection>(
+  '@jupyter/sql-cell:kernel-injection',
+  'A boolean, whether the function has been injected in the kernel or not'
+);
+
+/**
+ * The kernel injection status interface.
+ */
+export interface IKernelInjection {
+  /**
+   * Whether the current kernel has the function to populate data.
+   */
+  status: boolean;
+  /**
+   * A signal emitted when the status changes.
+   */
+  readonly statusChanged: ISignal<this, boolean>;
+}
+
+/**
+ * The kernel injection status class.
+ */
+export class KernelInjection implements IKernelInjection {
+  /**
+   * Getter and setter of the status.
+   */
+  get status(): boolean {
+    return this._status;
+  }
+  set status(value: boolean) {
+    this._status = value;
+    this.statusChanged.emit(value);
+  }
+  private _status = false;
+  readonly statusChanged = new Signal<this, boolean>(this);
+}

--- a/src/sidepanel.tsx
+++ b/src/sidepanel.tsx
@@ -69,6 +69,10 @@ export const IDatabasesPanel = new Token<IDatabasesPanel>(
  */
 export interface IDatabasesPanel {
   /**
+   * Get a database from its alias.
+   */
+  get_database(alias: string): Databases.IDatabase | undefined;
+  /**
    * The databases list.
    */
   readonly databases: Databases.IDatabase[];
@@ -105,9 +109,19 @@ export class Databases extends SidePanel implements IDatabasesPanel {
     content.expansionToggled.connect(this._onExpansionToogled, this);
   }
 
+  /**
+   * Get a database from its alias.
+   */
+  get_database(alias: string): Databases.IDatabase | undefined {
+    return this._databases.find(db => db.alias === alias);
+  }
+  /**
+   * Get the databases list.
+   */
   get databases(): Databases.IDatabase[] {
     return this._databases;
   }
+
   /**
    * A signal emitting when the databases are updated.
    */
@@ -146,7 +160,7 @@ export class Databases extends SidePanel implements IDatabasesPanel {
 /**
  * Namespace for the databases side panel.
  */
-namespace Databases {
+export namespace Databases {
   /**
    * Options of the databases side panel's constructor.
    */

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -1,7 +1,8 @@
 import { ICellModel } from '@jupyterlab/cells';
 import * as React from 'react';
 
-import { IDatabasesPanel } from './sidepanel';
+import { MAGIC } from './common';
+import { Databases, IDatabasesPanel } from './sidepanel';
 
 /**
  * A field including a select to associate a database.
@@ -11,24 +12,54 @@ export const DatabaseSelect = (options: {
   databasesPanel: IDatabasesPanel;
 }) => {
   const onChange = (event: React.FormEvent) => {
-    console.log(
-      `Value changed to '${(event.target as HTMLSelectElement).value}'`
-    );
+    const selection = (event.target as HTMLSelectElement).value;
+    const database = options.databasesPanel.get_database(selection);
+    if (options.cellModel && database) {
+      Private.changeDatabase(options.cellModel, database);
+    }
   };
-  console.log(options.databasesPanel);
   return (
     <div>
-      <div className="jp-FormGroup-fieldLabel"></div>
-      <select
-        onChange={onChange}
-        className={'form-control jp-sqlcell-select'}
-        disabled={options.cellModel?.type !== 'code'}
-      >
-        <option> - </option>
-        {options.databasesPanel?.databases.map(database => {
-          return <option>{database.alias}</option>;
-        })}
-      </select>
+      <label>
+        Database:&nbsp;
+        <select
+          onChange={onChange}
+          className={'jp-sqlcell-select'}
+          disabled={options.cellModel?.type !== 'code'}
+        >
+          <option> - </option>
+          {options.databasesPanel?.databases.map(database => {
+            return <option>{database.alias}</option>;
+          })}
+        </select>
+      </label>
     </div>
   );
 };
+
+/**
+ * The private namespace.
+ */
+namespace Private {
+  /**
+   * Update the contents of the magic line of the cell, accordingly to the selection.
+   *
+   * @param cellModel - the model of the cell whose contents are to be modified.
+   * @param database - the selected database.
+   */
+  export function changeDatabase(
+    cellModel: ICellModel,
+    database: Databases.IDatabase
+  ): void {
+    let magicLine = MAGIC;
+    magicLine += ` ${database.driver}`;
+    magicLine += '://';
+    magicLine += `/${database.database}`;
+    magicLine += database.port ? `:${database.port}` : '';
+
+    const source = cellModel.sharedModel.source;
+    const sourceArray = source.split('\n');
+    sourceArray[0] = magicLine;
+    cellModel.sharedModel.source = sourceArray.join('\n');
+  }
+}

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -1,0 +1,34 @@
+import { ICellModel } from '@jupyterlab/cells';
+import * as React from 'react';
+
+import { IDatabasesPanel } from './sidepanel';
+
+/**
+ * A field including a select to associate a database.
+ */
+export const DatabaseSelect = (options: {
+  cellModel: ICellModel | null;
+  databasesPanel: IDatabasesPanel;
+}) => {
+  const onChange = (event: React.FormEvent) => {
+    console.log(
+      `Value changed to '${(event.target as HTMLSelectElement).value}'`
+    );
+  };
+  console.log(options.databasesPanel);
+  return (
+    <div>
+      <div className="jp-FormGroup-fieldLabel"></div>
+      <select
+        onChange={onChange}
+        className={'form-control jp-sqlcell-select'}
+        disabled={options.cellModel?.type !== 'code'}
+      >
+        <option> - </option>
+        {options.databasesPanel?.databases.map(database => {
+          return <option>{database.alias}</option>;
+        })}
+      </select>
+    </div>
+  );
+};

--- a/style/base.css
+++ b/style/base.css
@@ -33,3 +33,9 @@ ul.jp-sqlcell-column-items {
   padding-inline-start: 2em;
   list-style-type: disc;
 }
+
+/* TOOLBAR */
+
+.jp-sqlcell-header .jp-Toolbar {
+  border-bottom: none;
+}

--- a/style/base.css
+++ b/style/base.css
@@ -36,6 +36,7 @@ ul.jp-sqlcell-column-items {
 
 /* TOOLBAR */
 
+/* stylelint-disable-next-line selector-class-pattern */
 .jp-sqlcell-header .jp-Toolbar {
   border-bottom: none;
 }

--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -23,7 +23,7 @@ for file in os.listdir(test_db_path):
   databases.append({
     "database":str(test_db_path / file),
     "dbms":"sqlite",
-    "driver":"aiosqlite",
+    "driver":"pysqlite",
     "alias":file_path.stem
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,14 +2055,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter/sql-cell@workspace:."
   dependencies:
+    "@jupyter/ydoc": ^1.0.0
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
+    "@jupyterlab/cells": ^4.0.0
+    "@jupyterlab/codeeditor": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
+    "@jupyterlab/notebook": ^4.0.0
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/testutils": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
     "@jupyterlab/ui-components": ^4.0.0
+    "@lumino/coreutils": ^2.0.0
+    "@lumino/messaging": ^2.0.0
     "@lumino/signaling": ^2.0.0
     "@lumino/widgets": ^2.0.0
     "@types/jest": ^29.2.0
@@ -2093,7 +2099,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter/ydoc@npm:^1.0.2":
+"@jupyter/ydoc@npm:^1.0.0, @jupyter/ydoc@npm:^1.0.2":
   version: 1.1.1
   resolution: "@jupyter/ydoc@npm:1.1.1"
   dependencies:
@@ -2219,7 +2225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/cells@npm:^4.0.8":
+"@jupyterlab/cells@npm:^4.0.0, @jupyterlab/cells@npm:^4.0.8":
   version: 4.0.8
   resolution: "@jupyterlab/cells@npm:4.0.8"
   dependencies:
@@ -2255,7 +2261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/codeeditor@npm:^4.0.8":
+"@jupyterlab/codeeditor@npm:^4.0.0, @jupyterlab/codeeditor@npm:^4.0.8":
   version: 4.0.8
   resolution: "@jupyterlab/codeeditor@npm:4.0.8"
   dependencies:
@@ -2458,7 +2464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/notebook@npm:^4.0.8":
+"@jupyterlab/notebook@npm:^4.0.0, @jupyterlab/notebook@npm:^4.0.8":
   version: 4.0.8
   resolution: "@jupyterlab/notebook@npm:4.0.8"
   dependencies:
@@ -2917,7 +2923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.1.2, @lumino/coreutils@npm:^2.1.2":
+"@lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.1.2, @lumino/coreutils@npm:^2.0.0, @lumino/coreutils@npm:^2.1.2":
   version: 2.1.2
   resolution: "@lumino/coreutils@npm:2.1.2"
   checksum: 7865317ac0676b448d108eb57ab5d8b2a17c101995c0f7a7106662d9fe6c859570104525f83ee3cda12ae2e326803372206d6f4c1f415a5b59e4158a7b81066f
@@ -2957,7 +2963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/messaging@npm:^2.0.1":
+"@lumino/messaging@npm:^2.0.0, @lumino/messaging@npm:^2.0.1":
   version: 2.0.1
   resolution: "@lumino/messaging@npm:2.0.1"
   dependencies:


### PR DESCRIPTION
This PR adds a toolbar in the code cell header if the kernel support SQL magic (from [jupysql](https://github.com/ploomber/jupysql) only). 

- the toolbar is displayed only if the cell contents start with `%%sql`.
- it includes a select widget connected to the database side panel, to populate easily the magic line.
- The command to load the SQL magic in the kernel (`%load_ext sql`) is silently run when the kernel is associated to the notebook. If the command fails, we assume the kernel does not support SQL magic.
