### PR TITLE
Refactoring

### DIFF
--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -85,6 +85,7 @@ export class VariableName extends ReactWidget {
     return (
       <input
         type={'text'}
+        placeholder={'Variable name'}
         onChange={this._onChange}
         title={'The variable where to copy the cell output'}
         defaultValue={this._value}

--- a/style/base.css
+++ b/style/base.css
@@ -39,4 +39,9 @@ ul.jp-sqlcell-column-items {
 /* stylelint-disable-next-line selector-class-pattern */
 .jp-sqlcell-header .jp-Toolbar {
   border-bottom: none;
+  align-items: center;
+}
+
+.jp-sqlcell-header .jp-Toolbar input {
+  height: 50%;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -42,6 +42,7 @@ ul.jp-sqlcell-column-items {
   align-items: center;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .jp-sqlcell-header .jp-Toolbar input {
   height: 50%;
 }


### PR DESCRIPTION
Before this PR, the cell content was watched from the header, to display or not the toolbar.
Now there is a custom code cell, there is no need to keep this logic in the header widget.

this PR moves this logic to the code cell itself.